### PR TITLE
docs: fix simple typo, onece -> once

### DIFF
--- a/demos/os/rtthread/stm32f4xx/RT-Thread-1.2.2/components/drivers/include/drivers/alarm.h
+++ b/demos/os/rtthread/stm32f4xx/RT-Thread-1.2.2/components/drivers/include/drivers/alarm.h
@@ -31,7 +31,7 @@
                                         to now.we also call it "don't care" value */
 
 /* alarm flags */
-#define RT_ALARM_ONESHOT       0x000 /* only alarm onece */
+#define RT_ALARM_ONESHOT       0x000 /* only alarm once */
 #define RT_ALARM_DAILY         0x100 /* alarm everyday */
 #define RT_ALARM_WEEKLY        0x200 /* alarm weekly at Monday or Friday etc. */
 #define RT_ALARM_MONTHLY       0x400 /* alarm monthly at someday */


### PR DESCRIPTION
There is a small typo in demos/os/rtthread/stm32f4xx/RT-Thread-1.2.2/components/drivers/include/drivers/alarm.h.

Should read `once` rather than `onece`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md