### PR TITLE
增加rtx5支持,修改字符格式化方式适应更多场合

### DIFF
--- a/cm_backtrace/Languages/en-US/cmb_en_US.h
+++ b/cm_backtrace/Languages/en-US/cmb_en_US.h
@@ -36,7 +36,7 @@
 [PRINT_MAIN_STACK_INFO]       = "====== Main stack information ======",
 [PRINT_THREAD_STACK_OVERFLOW] = "Error: Thread stack(%08x) was overflow",
 [PRINT_MAIN_STACK_OVERFLOW]   = "Error: Main stack(%08x) was overflow",
-[PRINT_CALL_STACK_INFO]       = "Show more call stack info by run: addr2line -e %s%s -a -f %.*s",
+[PRINT_CALL_STACK_INFO]       = "Show more call stack info by run: addr2line -e %s%s -a -f %s",
 [PRINT_CALL_STACK_ERR]        = "Dump call stack has an error",
 [PRINT_FAULT_ON_THREAD]       = "Fault on thread %s",
 [PRINT_FAULT_ON_HANDLER]      = "Fault on interrupt or bare metal(no OS) environment",

--- a/cm_backtrace/Languages/zh-CN/cmb_zh_CN.h
+++ b/cm_backtrace/Languages/zh-CN/cmb_zh_CN.h
@@ -36,7 +36,7 @@
 [PRINT_MAIN_STACK_INFO]       = "============ 主堆栈信息 ============",
 [PRINT_THREAD_STACK_OVERFLOW] = "错误：线程栈(%08x)发生溢出",
 [PRINT_MAIN_STACK_OVERFLOW]   = "错误：主栈(%08x)发生溢出",
-[PRINT_CALL_STACK_INFO]       = "查看更多函数调用栈信息，请运行：addr2line -e %s%s -a -f %.*s",
+[PRINT_CALL_STACK_INFO]       = "查看更多函数调用栈信息，请运行：addr2line -e %s%s -a -f %s",
 [PRINT_CALL_STACK_ERR]        = "获取函数调用栈失败",
 [PRINT_FAULT_ON_THREAD]       =  "在线程(%s)中发生错误异常",
 [PRINT_FAULT_ON_HANDLER]      = "在中断或裸机环境下发生错误异常",

--- a/cm_backtrace/Languages/zh-CN/cmb_zh_CN_UTF8.h
+++ b/cm_backtrace/Languages/zh-CN/cmb_zh_CN_UTF8.h
@@ -36,7 +36,7 @@
 [PRINT_MAIN_STACK_INFO]       = "============ 主堆栈信息 ============",
 [PRINT_THREAD_STACK_OVERFLOW] = "错误：线程栈(%08x)发生溢出",
 [PRINT_MAIN_STACK_OVERFLOW]   = "错误：主栈(%08x)发生溢出",
-[PRINT_CALL_STACK_INFO]       = "查看更多函数调用栈信息，请运行：addr2line -e %s%s -a -f %.*s",
+[PRINT_CALL_STACK_INFO]       = "查看更多函数调用栈信息，请运行：addr2line -e %s%s -a -f %s",
 [PRINT_CALL_STACK_ERR]        = "获取函数调用栈失败",
 [PRINT_FAULT_ON_THREAD]       =  "在线程(%s)中发生错误异常",
 [PRINT_FAULT_ON_HANDLER]      = "在中断或裸机环境下发生错误异常",

--- a/cm_backtrace/cm_backtrace.c
+++ b/cm_backtrace/cm_backtrace.c
@@ -207,6 +207,10 @@ static void get_cur_thread_stack_info(uint32_t sp, uint32_t *start_addr, size_t 
 #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_FREERTOS)   
     *start_addr = (uint32_t)vTaskStackAddr();
     *size = vTaskStackSize() * sizeof( StackType_t );
+#elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTX5)
+	osRtxThread_t *thread = osRtxInfo.thread.run.curr;
+	*start_addr = (uint32_t)thread->stack_mem;
+	*size = thread->stack_size;
 #endif
 }
 
@@ -231,6 +235,9 @@ static const char *get_cur_thread_name(void) {
     return (const char *)OSTCBCurPtr->NamePtr;
 #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_FREERTOS)
     return vTaskName();
+#elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTX5)
+	osThreadId_t id = osThreadGetId();
+	return osThreadGetName(id);
 #endif
 }
 
@@ -371,7 +378,8 @@ static void print_call_stack(uint32_t sp) {
     }
 
     if (cur_depth) {
-        cmb_println(print_info[PRINT_CALL_STACK_INFO], fw_name, CMB_ELF_FILE_EXTENSION_NAME, cur_depth * (8 + 1),
+		call_stack_info[cur_depth * (8 + 1) - 1] = '\0';
+        cmb_println(print_info[PRINT_CALL_STACK_INFO], fw_name, CMB_ELF_FILE_EXTENSION_NAME,
                 call_stack_info);
     } else {
         cmb_println(print_info[PRINT_CALL_STACK_ERR]);

--- a/cm_backtrace/cm_backtrace.c
+++ b/cm_backtrace/cm_backtrace.c
@@ -208,9 +208,9 @@ static void get_cur_thread_stack_info(uint32_t sp, uint32_t *start_addr, size_t 
     *start_addr = (uint32_t)vTaskStackAddr();
     *size = vTaskStackSize() * sizeof( StackType_t );
 #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTX5)
-	osRtxThread_t *thread = osRtxInfo.thread.run.curr;
-	*start_addr = (uint32_t)thread->stack_mem;
-	*size = thread->stack_size;
+    osRtxThread_t *thread = osRtxInfo.thread.run.curr;
+    *start_addr = (uint32_t)thread->stack_mem;
+    *size = thread->stack_size;
 #endif
 }
 
@@ -236,8 +236,8 @@ static const char *get_cur_thread_name(void) {
 #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_FREERTOS)
     return vTaskName();
 #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTX5)
-	osThreadId_t id = osThreadGetId();
-	return osThreadGetName(id);
+    osThreadId_t id = osThreadGetId();
+    return osThreadGetName(id);
 #endif
 }
 
@@ -378,9 +378,8 @@ static void print_call_stack(uint32_t sp) {
     }
 
     if (cur_depth) {
-		call_stack_info[cur_depth * (8 + 1) - 1] = '\0';
-        cmb_println(print_info[PRINT_CALL_STACK_INFO], fw_name, CMB_ELF_FILE_EXTENSION_NAME,
-                call_stack_info);
+        call_stack_info[cur_depth * (8 + 1) - 1] = '\0';
+        cmb_println(print_info[PRINT_CALL_STACK_INFO], fw_name, CMB_ELF_FILE_EXTENSION_NAME, call_stack_info);
     } else {
         cmb_println(print_info[PRINT_CALL_STACK_ERR]);
     }

--- a/cm_backtrace/cmb_cfg.h
+++ b/cm_backtrace/cmb_cfg.h
@@ -30,13 +30,13 @@
 #define _CMB_CFG_H_
 
 /* print line, must config by user */
-#define cmb_println(...)               /* e.g., printf(__VA_ARGS__);printf("\r\n") */
+#define cmb_println(...)               /* e.g., printf(__VA_ARGS__);printf("\r\n")  or  SEGGER_RTT_printf(0, __VA_ARGS__);SEGGER_RTT_WriteString(0, "\r\n")  */
 /* enable bare metal(no OS) platform */
 /* #define CMB_USING_BARE_METAL_PLATFORM */
 /* enable OS platform */
 /* #define CMB_USING_OS_PLATFORM */
 /* OS platform type, must config when CMB_USING_OS_PLATFORM is enable */
-/* #define CMB_OS_PLATFORM_TYPE           CMB_OS_PLATFORM_RTT or CMB_OS_PLATFORM_UCOSII or CMB_OS_PLATFORM_UCOSIII or CMB_OS_PLATFORM_FREERTOS */
+/* #define CMB_OS_PLATFORM_TYPE           CMB_OS_PLATFORM_RTT or CMB_OS_PLATFORM_UCOSII or CMB_OS_PLATFORM_UCOSIII or CMB_OS_PLATFORM_FREERTOS or CMB_OS_PLATFORM_RTX5 */
 /* cpu platform type, must config by user */
 #define CMB_CPU_PLATFORM_TYPE          /* CMB_CPU_ARM_CORTEX_M0 or CMB_CPU_ARM_CORTEX_M3 or CMB_CPU_ARM_CORTEX_M4 or CMB_CPU_ARM_CORTEX_M7 */
 /* enable dump stack information */

--- a/cm_backtrace/cmb_def.h
+++ b/cm_backtrace/cmb_def.h
@@ -46,6 +46,7 @@
 #define CMB_OS_PLATFORM_UCOSII            1
 #define CMB_OS_PLATFORM_UCOSIII           2
 #define CMB_OS_PLATFORM_FREERTOS          3
+#define CMB_OS_PLATFORM_RTX5              4
 
 #define CMB_PRINT_LANGUAGE_ENGLISH        0
 #define CMB_PRINT_LANGUAGE_CHINESE        1
@@ -336,6 +337,8 @@ if (!(EXPR))                                                                   \
         extern uint32_t *vTaskStackAddr(void);/* need to modify the FreeRTOS/tasks source code */
         extern uint32_t vTaskStackSize(void);
         extern char * vTaskName(void);
+    #elif (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTX5)
+        #include "rtx_os.h"
     #else
         #error "not supported OS type"
     #endif /* (CMB_OS_PLATFORM_TYPE == CMB_OS_PLATFORM_RTT) */


### PR DESCRIPTION
CmBacktrace是一个很好的项目，就是少了rtx5的支持。另外使用segger_rtt进行打印的时候，一些格式化字符串不支持。修改了