### PR TITLE
using error code instead of the long desc strings;

### DIFF
--- a/cm_backtrace/cm_backtrace.c
+++ b/cm_backtrace/cm_backtrace.c
@@ -112,6 +112,8 @@ static const char * const print_info[] = {
     #include "Languages/zh-CN/cmb_zh_CN.h"
 #elif (CMB_PRINT_LANGUAGE == CMB_PRINT_LANGUAGE_CHINESE_UTF8)
     #include "Languages/zh-CN/cmb_zh_CN_UTF8.h"
+#elif (CMB_PRINT_LANGUAGE == CMB_PRINT_LANGUAGE_CUSTOM)
+    #include "cmb_language_custom.h"
 #else
     #error "CMB_PRINT_LANGUAGE defined error in 'cmb_cfg.h'"
 #endif

--- a/cm_backtrace/cmb_def.h
+++ b/cm_backtrace/cmb_def.h
@@ -51,6 +51,7 @@
 #define CMB_PRINT_LANGUAGE_ENGLISH        0
 #define CMB_PRINT_LANGUAGE_CHINESE        1
 #define CMB_PRINT_LANGUAGE_CHINESE_UTF8   2
+#define CMB_PRINT_LANGUAGE_CUSTOM         0xFF
 
 /* name max length, default size: 32 */
 #ifndef CMB_NAME_MAX


### PR DESCRIPTION
using error code instead of the long desc strings,by doing this, the flash usage can reduce 1488 B:

## using English
```
#define CMB_PRINT_LANGUAGE CMB_PRINT_LANGUAGE_ENGLISH
```
```
Memory region         Used Size  Region Size  %age Used
          CCMRAM:          0 GB        64 KB      0.00%
             RAM:       65520 B       120 KB     53.32%
           FLASH:      137000 B         1 MB     13.07%
```
## using error code
```
#define CMB_PRINT_LANGUAGE CMB_PRINT_LANGUAGE_ERROR_CODE
```
```
Memory region         Used Size  Region Size  %age Used
          CCMRAM:          0 GB        64 KB      0.00%
             RAM:       65520 B       120 KB     53.32%
           FLASH:      135512 B         1 MB     12.92%
```