### PR TITLE
fix: 🔒 优化keil AC6的警告问题,提供更优的fault函数替换方式

### DIFF
--- a/cm_backtrace/cm_backtrace.c
+++ b/cm_backtrace/cm_backtrace.c
@@ -26,7 +26,7 @@
  * Created on: 2016-12-15
  */
 
-#include <cm_backtrace.h>
+#include "cm_backtrace.h"
 #include <stdbool.h>
 #include <string.h>
 #include <stdio.h>
@@ -167,7 +167,7 @@ void cm_backtrace_init(const char *firmware_name, const char *hardware_ver, cons
 #endif
 
     if (main_stack_size == 0) {
-        cmb_println(print_info[PRINT_MAIN_STACK_CFG_ERROR]);
+        cmb_println("%s", print_info[PRINT_MAIN_STACK_CFG_ERROR]);
         return;
     }
 
@@ -277,9 +277,9 @@ static void dump_stack(uint32_t stack_start_addr, size_t stack_size, uint32_t *s
             stack_pointer = (uint32_t *) (stack_start_addr + stack_size);
         }
     }
-    cmb_println(print_info[PRINT_THREAD_STACK_INFO]);
+    cmb_println("%s", print_info[PRINT_THREAD_STACK_INFO]);
     for (; (uint32_t) stack_pointer < stack_start_addr + stack_size && deep; stack_pointer++, deep--) {
-        cmb_println("  addr: %08x    data: %08x", stack_pointer, *stack_pointer);
+        cmb_println("  addr: %08x    data: %08x", (uint32_t) stack_pointer, *stack_pointer);
     }
     cmb_println("====================================");
 }
@@ -423,7 +423,7 @@ static void print_call_stack(uint32_t sp) {
         cmb_println(print_info[PRINT_CALL_STACK_INFO], fw_name, CMB_ELF_FILE_EXTENSION_NAME, cur_depth * (8 + 1),
                 call_stack_info);
     } else {
-        cmb_println(print_info[PRINT_CALL_STACK_ERR]);
+        cmb_println("%s", print_info[PRINT_CALL_STACK_ERR]);
     }
 }
 
@@ -646,7 +646,7 @@ void cm_backtrace_fault(uint32_t fault_handler_lr, uint32_t fault_handler_sp) {
     }
 #else
     /* bare metal(no OS) environment */
-    cmb_println(print_info[PRINT_FAULT_ON_HANDLER]);
+    cmb_println("%s", print_info[PRINT_FAULT_ON_HANDLER]);
 #endif /* CMB_USING_OS_PLATFORM */
 
     /* delete saved R0~R3, R12, LR,PC,xPSR registers space */
@@ -676,7 +676,7 @@ void cm_backtrace_fault(uint32_t fault_handler_lr, uint32_t fault_handler_sp) {
 
     {
         /* dump register */
-        cmb_println(print_info[PRINT_REGS_TITLE]);
+        cmb_println("%s", print_info[PRINT_REGS_TITLE]);
 
         regs.saved.r0        = ((uint32_t *)saved_regs_addr)[0];  // Register R0
         regs.saved.r1        = ((uint32_t *)saved_regs_addr)[1];  // Register R1

--- a/cm_backtrace/cmb_def.h
+++ b/cm_backtrace/cmb_def.h
@@ -29,7 +29,7 @@
 #ifndef _CMB_DEF_H_
 #define _CMB_DEF_H_
 
-#include <cmb_cfg.h>
+#include "cmb_cfg.h"
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -371,7 +371,7 @@ if (!(EXPR))                                                                   \
         mov r0, sp
         bx lr
     }
-#elif defined(__CLANG_ARM)
+#elif defined(__CLANG_ARM) || (defined(__ARMCC_VERSION) && (__ARMCC_VERSION >= 6010050))
     __attribute__( (always_inline) ) static __inline uint32_t cmb_get_msp(void) {
         uint32_t result;
         __asm volatile ("mrs %0, msp" : "=r" (result) );

--- a/cm_backtrace/fault_handler/keil/replace_fault.c
+++ b/cm_backtrace/fault_handler/keil/replace_fault.c
@@ -1,0 +1,39 @@
+
+/**
+ * @file replace_fault.c
+ * @author fool_dog (2696652257@qq.com)
+ * @brief 借助ARMLinker的$Super$$Sub$机制，替换Keil中的HardFault_Handler
+ *            这样HAL库重新生成的时候不用注释掉HardFault_Handler,与cmb_fault.s二选一添加编译
+ * @note 需要ARMLinker支持，Keil环境下使用
+ * @version 1.0
+ * @date 2024-08-20
+ * 
+ * @copyright Copyright (c) 2024
+ * 
+ */
+
+#include <stdint.h>
+
+/* 声明一下老版本的HardFault_Handler */
+extern void $Super$$HardFault_Handler(void);
+
+extern void cm_backtrace_fault(uint32_t fault_handler_lr, uint32_t fault_handler_sp);
+
+/* 新版本的HardFault_Handler */
+__attribute__((used)) void $Sub$$HardFault_Handler(void)
+{
+    uint32_t lr, sp;
+
+    __asm__ volatile(
+        "mov %0, lr\n"
+        "mov %1, sp\n"
+        : "=r"(lr), "=r"(sp)
+        :
+        : "memory");
+
+    /*  调用cm_backtrace_fault函数 */
+    cm_backtrace_fault(lr, sp);
+
+    /* 调用原来的HardFault_Handler */
+    $Super$$HardFault_Handler();
+}


### PR DESCRIPTION
1. 使用相对路径包含头文件
2. keil V5.36,AC6编译器错误进入`__GNUC__`预处理宏导致register警告
3. 修改几处字符串输出未使用格式说明符导致的警告
4. 利用ArmLink的$$Super$与$$Sub$机制,无感且一劳永逸的替换fault中断,避免使用cubemx等工具生成代码时每次覆盖更改